### PR TITLE
Add TBD Predict to Prediction Markets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -422,6 +422,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [Parsec](https://github.com/parsecular/parsec-mcp) | `Rust`, `TypeScript`, `Python` | - Prediction market data, execution, and live streams across all major exchanges. [Website](https://parsecapi.com)
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) | `Python`, `JavaScript` | - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs. [(Demo)](https://profitplay-1066795472378.us-east1.run.app)
 - [pykalshi](https://github.com/ArshKA/kalshi-client) ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/ArshKA/kalshi-client/main) ![GitHub Repo stars](https://img.shields.io/github/stars/ArshKA/kalshi-client?style=social) | `Python` | - Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
+- [TBD Predict](https://github.com/ego-protocol/tbd-vote-cli) | `TypeScript` | - Solana-based prediction market for human opinions with an agent CLI (`@tbd-vote/cli`) and AGENTS.md spec for AI agents to authenticate, list opinion campaigns, and place bets via JSON-friendly commands. [Website](https://www.tbd.vote)
 
 ## Broker APIs
 


### PR DESCRIPTION
Adds TBD Predict to the Prediction Markets section under Data Source.

TBD Predict is a Solana-based prediction market for human opinions — wagering on what people think and believe, not just objective event outcomes. The `@tbd-vote/cli` npm package and AGENTS.md spec at https://www.tbd.vote/agents/AGENTS.md let AI agents and quant systems authenticate, browse opinion campaigns, and place bets via JSON-friendly commands.

Closest peer in this section: ProfitPlay Agent Arena (also a prediction market for AI agents).

- Website: https://www.tbd.vote
- CLI: https://github.com/ego-protocol/tbd-vote-cli
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli