### PR TITLE
Add Helium MCP (alternative market data + MCP)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -408,6 +408,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [SEC EDGAR Filing API](https://github.com/janlukasschroeder/sec-api-python)
 - [edgartools](https://github.com/dgunning/edgartools) |`Python`| - SEC EDGAR data for quant strategies — fundamentals, institutional holdings (13F), insider transactions, and corporate events (8-K). Includes MCP server for AI workflows.
 - [CongressionalStockBrain](https://congressionalstockbrain.com) - AI-powered STOCK Act disclosure tracker that converts U.S. lawmaker trade filings into machine-scored signals for retail investors. Alternative data source for equity quant strategies. Free tier available.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/connerlambden/helium-mcp/main) ![GitHub Repo stars](https://img.shields.io/github/stars/connerlambden/helium-mcp?style=social) | `REST API`, `MCP` | - Real-time stock, ETF, and crypto data with AI bull/bear cases and price forecasts; ML options fair value (probability ITM, full Greeks); top-ranked options strategies (short vol, long vol); and news sentiment from 5,000+ sources. MCP server with REST endpoints. Free tier: 50 queries, no auth. [Website](https://heliumtrades.com/mcp-page/)
 
 ### Crypto
 


### PR DESCRIPTION
## Summary

Adds **[Helium MCP](https://github.com/connerlambden/helium-mcp)** to **Data Source → Alternative**, where other alternative-data and MCP-friendly tools are listed.

## Why it fits systematic trading

- Live **stock / ETF / crypto** context with AI bull/bear cases and price outlooks  
- **ML options** fair value, probability ITM, and full Greeks  
- **Ranked options strategies** (short vol, long vol)  
- **News sentiment** across 5,000+ sources as alternative data  

Delivery: **MCP server** and **REST** endpoints. Free tier: **50 queries, no auth**.  
Docs: [heliumtrades.com/mcp-page/](https://heliumtrades.com/mcp-page/)

## Change

- One new bullet under `### Alternative` in `Readme.md`, matching existing list style (badges + pipe-delimited tags).

Made with [Cursor](https://cursor.com)