### PR TITLE
Add Microverse Systems to crypto data providers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -420,6 +420,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [DexPaprika](https://api.dexpaprika.com) | `REST API` | - Free DEX/DeFi data API covering pools, tokens, OHLCV, and trade history across all chains and DEXes. No API key, no rate limits.
 - [PreReason](https://github.com/PreReason/mcp) | `TypeScript`, `REST API`, `MCP` | - Pre-analyzed Bitcoin and macro market briefings. 17 contexts covering BTC, Fed balance sheet, M2, Treasury yields, hash rate, difficulty, mining production costs, and cross-asset correlations (SPY, QQQ, VXX, UUP as BTC relationship signals). Returns trend direction, confidence scores, percentile rankings, and regime classification. [Website](https://www.prereason.com)
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action & volume spikes dashboard for crypto traders. Free, no sign-up required.
+- [Microverse Systems](https://microversesystems.com) - Real-time L2 order books from 21 exchanges. Free WebSocket API, historical replay, sub-ms latency.
 
 ### Prediction Markets
 


### PR DESCRIPTION
## Summary
- Adds [Microverse Systems](https://microversesystems.com) to the Crypto section under Data Source
- Real-time L2 order books from 21 exchanges with free WebSocket API, historical replay, and sub-ms latency

## Test plan
- [ ] Verify link resolves correctly
- [ ] Confirm entry fits the existing list format

🤖 Generated with [Claude Code](https://claude.com/claude-code)