### PR TITLE
Add hurst-calculator to TimeSeries Analysis

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -350,6 +350,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [tsfresh](https://github.com/blue-yonder/tsfresh) - Automatic extraction of relevant features from time series.
 - [Facebook Prophet](https://github.com/facebook/prophet) - Tool for producing high quality forecasts for time series data that has multiple seasonality with linear or non-linear growth.
 - [pmdarima](https://github.com/alkaline-ml/pmdarima) - A statistical library designed to fill the void in Python's time series analysis capabilities, including the equivalent of R's auto.arima function.
+- [hurst-calculator](https://github.com/Osamwonyi18/hurst-calculator) - Rescaled Range (R/S) analysis for estimating the Hurst exponent of a time series. Classifies series as mean-reverting, random walk, or trending. NumPy-only, single-file Python.
 
 ## Visualization
 


### PR DESCRIPTION
Adds [hurst-calculator](https://github.com/Osamwonyi18/hurst-calculator), a small NumPy-only Python library for estimating the Hurst exponent of a time series using Rescaled Range (R/S) analysis.

**What it does**
- Log-spaced lag sampling across the series
- Non-overlapping segment R/S computation
- OLS fit on log(R/S) vs log(lag); slope is H
- Returns interpretation (mean-reverting / random walk / trending), R² confidence, and stderr

**Why it fits this list**
Hurst classification is a standard first step in systematic strategy design (regime gate for mean-reversion vs momentum logic). Existing entries cover broader backtesting / data frameworks but not a focused, dependency-light Hurst library.

Single file, MIT licensed, documented examples against random walk, trending, and mean-reverting synthetic series.