### PR TITLE
Add Solo Crypto Quant Starter Kit to Tutorials

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -493,6 +493,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 ### Tutorials
 
 - [Algorithmic Trading for Cryptocurrencies in Python](https://github.com/tudorelu/tudorials/tree/master/trading) - A simple yet practical experiment tutorial for cryto trading.
+- [Solo Crypto Quant Starter Kit](https://github.com/cryptomotifs/cipher-starter) - A 150-page playbook for building a Solana-native signal engine + autonomous trading bot solo on $0/mo infrastructure. Covers universe selection, top-K signal filtering, eighth-Kelly sizing, MEV sandwich defenses, three-tier wallet architecture, Canadian NI 31-103 compliance, and Oracle Cloud Always Free deploy. [Landing page](https://cryptomotifs.github.io/cipher-starter/).
 
 ### Courses
 


### PR DESCRIPTION
Adding a new resource under **Tutorials**:

**Solo Crypto Quant Starter Kit** — 150-page free/open research bundle for solo devs building a Solana-native signal engine + autonomous trading bot on $0/mo infrastructure.

Contents (12 playbooks):
- Trading universe, top-K signal filtering, eighth-Kelly sizing, ATR-based stops
- Risk: 5 circuit breakers, 30-day paper-trade gate, incident runbooks
- Security: three-tier wallet architecture, KMS envelope, isolated signer subprocess
- Architecture: 18-module breakdown, 7-day MVP calendar, SQL schemas
- Compliance (Canadian): NI 31-103 exemption path, SR&ED tax credit guidance
- Infrastructure: Oracle Cloud Always Free deploy, 99% SLO, P0 alert runbooks
- Salvage audit of prior bot attempts + 3 anti-patterns to avoid
- ~1000-tool audit with 30 P0 picks

Repo: https://github.com/cryptomotifs/cipher-starter (MIT license, all content public in `bundle/`)
Landing page: https://cryptomotifs.github.io/cipher-starter/

Happy to move it to a different section if Tutorials isn't the best fit.