### PR TITLE
Add 13F Insight to Alternative Data Sources

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -408,6 +408,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 ### Alternative
 
 - [Adanos Market Sentiment API](https://api.adanos.org/docs/) | `REST API` | - Cross-platform market sentiment API for equities using Reddit, X/Twitter, and Polymarket signals; returns trending tickers, buzz scores, and sentiment snapshots for quant workflows.
+- [13F Insight](https://13finsight.com/?utm_source=github&utm_medium=referral&utm_campaign=seo_outreach_20260422&utm_content=wangzhe3224_awesome-systematic-trading) - AI-powered platform for tracking institutional investor 13F holdings; covers 5,000+ managers with position change alerts, concentration analysis, and quarterly filing summaries. Free tier available.
 - [SEC EDGAR Filing API](https://github.com/janlukasschroeder/sec-api-python)
 - [edgartools](https://github.com/dgunning/edgartools) |`Python`| - SEC EDGAR data for quant strategies — fundamentals, institutional holdings (13F), insider transactions, and corporate events (8-K). Includes MCP server for AI workflows.
 - [CongressionalStockBrain](https://congressionalstockbrain.com) - AI-powered STOCK Act disclosure tracker that converts U.S. lawmaker trade filings into machine-scored signals for retail investors. Alternative data source for equity quant strategies. Free tier available.


### PR DESCRIPTION
Adds [13F Insight](https://13finsight.com) to the **Alternative Data Sources** section, alongside SEC EDGAR Filing API and edgartools.

**Why it fits:**
- The section already covers EDGAR API and edgartools for raw SEC filings; 13F Insight sits one layer above: it turns raw 13F filing data into investor-facing manager portfolio tracking, position change analysis, and quarterly filing summaries
- Relevant for systematic traders who want to monitor institutional ownership changes, hedge fund concentration shifts, and filing-season signals (e.g. D.E. Shaw exiting QQQ, Appaloosa reducing from 45→38 holdings)
- Covers 5,000+ managers with AI-powered quarterly change detection; free tier available

**What it is:**
- Website: https://13finsight.com
- Tracks institutional investor 13F holdings with position change alerts, concentration analysis, and portfolio summaries
- Complements SEC EDGAR raw data access with research-ready holdings intelligence