### PR TITLE
Add FilingFirehose (SEC EDGAR with body-text classification) to Data Sources

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -388,6 +388,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [kdb](https://github.com/KxSystems) | `q` | - Companion files to kdb+ and q
 
 ## Data Source
+- [FilingFirehose](https://github.com/jaablon/filingfirehose-python) - SEC EDGAR JSON API with body-text-classified 8-Ks (catches buried items: 7.3% of Item 8.01 filings flagged), 13D/G with 21+ activist filers tagged, S-3/424B5 ATM detection. Free 72h tier, paid full archive from $29/mo. REST + MCP + Python SDK + GitHub Action.
 
 ### Stocks and General
 


### PR DESCRIPTION
Adds FilingFirehose, an SEC EDGAR JSON API I built that body-text-classifies every 8-K and flags items the filer didn't report (7.3% of recent Item 8.01 filings have buried 1.05/5.02/etc events). Tags 21+ activist filers on every Schedule 13D/G; detects ATM offerings on S-3/424B5.

For systematic traders: free public tier (no auth, last 72h), paid tier from $29/mo for full historical archive + webhooks. Available as REST API, MCP server (Claude Desktop / Cursor / Windsurf), Python SDK, GitHub Action, and ChatGPT GPT.

- Site: https://filingfirehose.com
- Research: https://filingfirehose.com/research/buried-events
- Free public API: https://filingfirehose.com/v1/public/8k?suspected_buried_only=true