### PR TITLE
Add Wickra to Indicators

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -322,6 +322,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [kand](https://github.com/rust-ta/kand) | `Rust` & `Python` | - A blazingly fast technical analysis library in Rust and Python.
 - [chart-patterns](https://github.com/focus1691/chart-patterns) | `TypeScript` | - Technical analysis library for chart patterns, price action, and volume-based pattern detection.
 - [ChartScout](https://chartscout.io) - Real-time crypto chart pattern detection and alerts
+- [Wickra](https://github.com/wickra-lib/wickra) | `Rust` & `Python` & `JavaScript` & `C++` & `C#` & `Go` & `Java` & `R` | - Streaming-first technical-analysis library with 514 O(1)-per-tick indicators across 24 families; bit-exact batch and streaming from one Rust core.
 
 
 ### Pricing


### PR DESCRIPTION
Adds Wickra under Analytic tools -> Indicators (next to TA-Lib, ta-rust, kand, pandas-ta).

Wickra is an open-source (MIT OR Apache-2.0) multi-language technical-analysis library: a Rust core with native Python, Node.js and WebAssembly bindings, plus a C ABI for C, C++, C#/.NET, Go, Java and R. Every indicator is an O(1)-per-tick state machine, so the same code runs your backtest and your live trading loop.

Highlights:
- 514 indicators across 24 families, including market microstructure, order-flow/derivatives, market profile and Ehlers DSP cycles - areas most TA libraries skip.
- batch == streaming is bit-exact, fuzzed and 100%-line-covered for all 514, so a backtested signal behaves identically live.
- 11-56x faster than the only other incremental peer in streaming; no recompute-on-every-tick.
- Batteries included: indicator chaining, a streaming OHLCV CSV reader, and a live Binance kline feed.
- No system dependencies; install in one line. MIT OR Apache-2.0.

Published on crates.io, PyPI, npm, NuGet, Maven Central, Go modules and r-universe.
Repo: https://github.com/wickra-lib/wickra
