### PR TITLE
Add honest-signals to Analytic tools > Metrics computation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -313,6 +313,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 
 - [alphalens (Fork)](https://github.com/wangzhe3224/alphalens) | `Python` | - Performance analysis of predictive (alpha) stock factors
 - [ffn](https://github.com/pmorissette/ffn) | `Python` | - A financial function library for Python
+- [honest-signals](https://github.com/MarvinRey7879/honest-signals) | `Python` | - Scores detected chart patterns against the pattern-free baseline for the same market and timeframe, reporting lift with cluster-robust confidence intervals instead of a hit rate against 50%
 - [quantstats](https://github.com/ranaroussi/quantstats) | `Python` | - Portfolio analytics for quants, written in Python
 
 ### Indicators


### PR DESCRIPTION
Adds one entry under **Analytic tools > Metrics computation**, next to alphalens — alphalens asks whether an alpha factor predicts anything; this asks the same question of chart patterns.

**The problem it addresses.** Pattern hit rates are conventionally read against 50%. In a drifting market that reference manufactures findings. Measured over 46,038 independent 10-bar windows on the daily US stock corpus, price closed higher 57.84% of the time and lower 42.00% with no pattern present. So "bearish engulfing hits only 41.3%, fade it" is 0.7pp off the market's own drift — nothing at all.

`honest-signals` takes a watchlist and prints each detected pattern's hit rate beside the pattern-free baseline for the same universe, timeframe, horizon and direction, then reports the difference with an interval on the difference:

```
Ticker   Pattern             Dir   Bars  Hit rate  Baseline  Lift     Lift 95% CI       n  Verdict
BTCUSDT  double_top          bear     1  60.4%     50.6%     +9.8pp   +/-8.4pp        149  BEATS BASELINE
SPY      bearish_engulfing   bear     2  41.3%     42.0%     -0.7pp   +/-2.6pp     12,842  NO EDGE
SPY      head_and_shoulders  bear     1  42.0%     42.0%     +0.0pp   +/-3.1pp      2,795  NO EDGE
```

Intervals are cluster-robust (sandwich estimator, clustered on the UTC day), since a bearish engulfing on AAPL and one on MSFT the same day is one market move counted twice. That matters: across 105 measured cells, a naive Wald interval calls 14 of them findings, cluster-robust calls 3 — and none survives a Bonferroni correction for 105 comparisons.

**Disclosure:** I wrote it, and it reads from the patternfetch API, which I also run. It works against a keyless public endpoint, so it is testable with no account and no key:

```bash
git clone https://github.com/MarvinRey7879/honest-signals && cd honest-signals
pip install -e ".[cli]"
honest-signals check MSFT SPY NVDA
```

MIT, Python 3.10+, CI green, 219 tests. Format matches the surrounding entries in that section (pipe-delimited, language tag, no trailing period). Not yet on PyPI, so the link is the repo.