### PR TITLE
Add AltData Atlas to Data Source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -396,6 +396,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 
 ## Data Source
 - [FilingFirehose](https://github.com/jaablon/filingfirehose-python) - SEC EDGAR JSON API with body-text-classified 8-Ks (catches buried items: 7.3% of Item 8.01 filings flagged), 13D/G with 21+ activist filers tagged, S-3/424B5 ATM detection. Free 72h tier, paid full archive from $29/mo. REST + MCP + Python SDK + GitHub Action.
+- [AltData Atlas](https://altdataatlas.com) - Open directory of alternative data providers for systematic and fundamental investors.
 
 ### Stocks and General
 


### PR DESCRIPTION
Adds [AltData Atlas](https://altdataatlas.com) — a free, open directory of 361 alternative data providers across 20 categories (coverage, history depth, delivery method, indicative price band). Useful as a sourcing reference when hunting datasets for systematic strategies. No signup, no paywall.