### PR TITLE
Add polymarket-canary-tape dataset to Data Source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -400,6 +400,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 ## Data Source
 - [FilingFirehose](https://github.com/jaablon/filingfirehose-python) - SEC EDGAR JSON API with body-text-classified 8-Ks (catches buried items: 7.3% of Item 8.01 filings flagged), 13D/G with 21+ activist filers tagged, S-3/424B5 ATM detection. Free 72h tier, paid full archive from $29/mo. REST + MCP + Python SDK + GitHub Action.
 - [AltData Atlas](https://altdataatlas.com) - Open directory of alternative data providers for systematic and fundamental investors.
+- [polymarket-canary-tape](https://huggingface.co/datasets/oraclemangle/polymarket-canary-tape) - Free CC-BY-4.0 prediction-market microstructure tape: 271M CEX trades + 61M Polymarket order-book WebSocket events (Apr-Jul 2026), including a dual-vantage overlap window for latency studies. Companion open-source bot lab: [polymarket-bot-lab](https://github.com/oraclemangle/polymarket-bot-lab).
 
 ### Stocks and General
 


### PR DESCRIPTION
Adds a free CC-BY-4.0 prediction-market microstructure dataset: 271M CEX trades + 61M Polymarket order-book events over Apr-Jul 2026, with a dual-vantage overlap window (two independent recorders, same markets) useful for latency and feed-consistency research. Hosted on Hugging Face with full schema docs and a parquet preview; companion Apache-2.0 bot-lab repo linked. One item, matches section format.