### PR TITLE
Add QuantCheck (Deflated Sharpe backtest validator) + free risk calculators

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -347,6 +347,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [pyfolio](https://github.com/quantopian/pyfolio) | `Python` | - Portfolio and risk analytics in Python
 - [curistat](https://github.com/moxiespirit/MyClone/tree/main/volatility_platform) | `Python` | - Futures volatility forecasting for ES/NQ. Daily CVN rating (1-10), regime detection (CRC composite), directional signals, economic event impact analytics. Includes MCP server for AI agent integration.
 - [System R](https://agents.systemr.ai) | `Python` | - Risk intelligence API for trading agents. Pre-trade gate with position sizing (G-formula/Kelly), drawdown analysis, Monte Carlo simulation, regime detection. REST API and MCP server.
+- [QuantDojo Tools Hub](https://quantdojo.ai/tools/) – Free, no-login web calculators for position sizing, Kelly criterion, risk/reward, drawdown recovery, Sharpe ratio, and trading expectancy.
 
 ### Optimization
 


### PR DESCRIPTION
## What this PR adds

Two additions to the list:

### Backtesting / Validation

- **[QuantCheck](https://quanttrader-quantcheck.hf.space)** – Free, no-code backtest validation tool. Computes the Deflated Sharpe Ratio and applies multiple-testing correction to flag whether a strategy's edge is real or an artefact of overfitting. No login required. Fills a gap in the current backtesting section (no existing entry covers Deflated Sharpe / multiple-testing-corrected validation).

### Risk Calculators

- **[QuantDojo Tools Hub](https://quantdojo.ai/tools/)** – Suite of free, no-login web calculators: position sizing, risk/reward & break-even win rate, drawdown recovery, Kelly criterion, Sharpe ratio, and trading expectancy.

---

Both are free, require no signup, and are consistent with the web-platform entries already in the list. Happy to adjust section placement or wording to fit your conventions.

— Wolfgang Lämmle, QuantDojo (quantdojo.ai)