### PR TITLE
Add WealthVille to Data Source > Crypto

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -455,6 +455,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [Market Posture Daily](https://marketpd.com) - Daily trend, regime and relative-strength data for ~90 crypto assets and US stocks/ETFs (price vs the 50/200-day trend, momentum, correlation) plus a cointegration pair screener. Free terminal + JSON API.
 - [BitBank](https://bitbank.nz) | `REST API` | - AI-powered crypto forecasting and predictions API with machine learning models for price movement analysis.
 - [AgentServices](https://github.com/vbkotecha/aiservices-api) | `REST API`, `MCP`, `x402` | - Crypto & market data API platform with 54 services, 97 endpoints, and 37 MCP tools. On-chain payments via x402 (USDC on Base). Covers prices, OHLCV, on-chain metrics, DeFi data, and technical indicators. [Server](https://agentservices.to)
+- [WealthVille](https://wealthville.net/api/v1) | `REST API`, `MCP` | - DeFi liquidity-pool scoring for LP/yield strategies. Covers ~68,800 Solana pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC. Returns a 0-100 pool score plus an ENTER/HOLD/EXIT/REDUCE/AVOID verdict with per-protocol calibrated confidence, and publishes a miss-inclusive 30-day track record so the signal can be evaluated before it is used. No API key required. Endpoints: `/pools/top`, `/evm/pools`, `/signals/feed`, `/track-record`. [Website](https://wealthville.net/developers)
 
 ### Prediction Markets
 


### PR DESCRIPTION
Adds one entry to **Data Source → Crypto**.

**WealthVille** is a liquidity-pool scoring API for LP and yield strategies — a layer above raw pool data rather than another OHLCV feed.

- **Coverage** — ~68,800 Solana pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC.
- **Output** — a 0-100 pool score and an ENTER / HOLD / EXIT / REDUCE / AVOID verdict, with confidence calibrated per protocol rather than pooled across all of them.
- **Evaluable** — `/track-record` is miss-inclusive over a rolling 30 days. Current numbers: ENTER 0.63 hit rate across 3,043 resolved calls, EXIT 0.69, AVOID 1.00 on n=36, and REDUCE 0.00 on n=16. The weak class is published with the rest on purpose, so the signal can be judged before anyone trades it.

No API key and no rate limit. All four endpoints cited in the entry return 200 as of this PR: `/pools/top`, `/evm/pools`, `/signals/feed`, `/track-record`.

Disclosure: I maintain this project. Happy to trim the entry if it runs long against the section's style.