### PR TITLE
Add DepthFeed prediction-market data source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -459,6 +459,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 
 ### Prediction Markets
 
+- [DepthFeed](https://depthfeed.com) | `REST API`, `WebSocket`, `MCP` | - Historical and live order-book data for prediction markets across Polymarket, Kalshi, Limitless, and Predict.fun, with backtesting-ready depth and liquidity analytics. [Docs](https://depthfeed.com/docs) [MCP](https://github.com/vcorp-dev/depthfeed-mcp)
 - [Parsec](https://github.com/parsecular/parsec-mcp) | `Rust`, `TypeScript`, `Python` | - Prediction market data, execution, and live streams across all major exchanges. [Website](https://parsecapi.com)
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) | `Python`, `JavaScript` | - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs. [(Demo)](https://profitplay-1066795472378.us-east1.run.app)
 - [pykalshi](https://github.com/ArshKA/kalshi-client) ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/ArshKA/kalshi-client/main) ![GitHub Repo stars](https://img.shields.io/github/stars/ArshKA/kalshi-client?style=social) | `Python` | - Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.


### PR DESCRIPTION
## Summary

Add DepthFeed to **Data Source → Prediction Markets**.

DepthFeed provides historical and live order-book data for Polymarket, Kalshi, Limitless, and Predict.fun through documented REST, WebSocket, and MCP interfaces. The listing is specifically relevant to systematic researchers because it exposes full bid/ask depth for backtesting and liquidity analysis rather than only market prices.

## Verification

- Official site: https://depthfeed.com
- API documentation: https://depthfeed.com/docs
- Public first-party MCP repository: https://github.com/vcorp-dev/depthfeed-mcp
- The linked pages and repository returned HTTP 200 when checked.
- The change is limited to one entry in the existing Prediction Markets subsection.

## Disclosure

I am affiliated with DepthFeed and am submitting this first-party listing for maintainer review.
