### PR TITLE
将 Jacobian 加入量化研究工具

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -316,8 +316,8 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 
 - [alphalens (Fork)](https://github.com/wangzhe3224/alphalens) | `Python` | - Performance analysis of predictive (alpha) stock factors
 - [ffn](https://github.com/pmorissette/ffn) | `Python` | - A financial function library for Python
-- [Jacobian](https://github.com/morluto/jacobian) | `Python`, `MCP`, `CLI` | - Composable mathematics for agent-driven quant research, with exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.
 - [honest-signals](https://github.com/MarvinRey7879/honest-signals) | `Python` | - Scores detected chart patterns against the pattern-free baseline for the same market and timeframe, reporting lift with cluster-robust confidence intervals instead of a hit rate against 50%
+- [Jacobian](https://github.com/morluto/jacobian) | `Python`, `MCP`, `CLI` | - Composable mathematics for agent-driven quant research, with exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.
 - [quantstats](https://github.com/ranaroussi/quantstats) | `Python` | - Portfolio analytics for quants, written in Python
 
 ### Indicators

--- a/Readme.md
+++ b/Readme.md
@@ -316,6 +316,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 
 - [alphalens (Fork)](https://github.com/wangzhe3224/alphalens) | `Python` | - Performance analysis of predictive (alpha) stock factors
 - [ffn](https://github.com/pmorissette/ffn) | `Python` | - A financial function library for Python
+- [Jacobian](https://github.com/morluto/jacobian) | `Python`, `MCP`, `CLI` | - Composable mathematics for agent-driven quant research, with exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.
 - [honest-signals](https://github.com/MarvinRey7879/honest-signals) | `Python` | - Scores detected chart patterns against the pattern-free baseline for the same market and timeframe, reporting lift with cluster-robust confidence intervals instead of a hit rate against 50%
 - [quantstats](https://github.com/ranaroussi/quantstats) | `Python` | - Portfolio analytics for quants, written in Python
 

--- a/Readme_cn.md
+++ b/Readme_cn.md
@@ -182,6 +182,7 @@ Note: 如果标有`Live Trading` 表示具有实时交易功能（至少一个�
 ### 指标计算 Metrics computation
 
 - [ffn](https://github.com/pmorissette/ffn) | `Python` | - Python的金融函数库
+- [Jacobian](https://github.com/morluto/jacobian) | `Python`、`MCP`、`CLI` | - 面向 Agent 的可组合数学工具，为量化研究提供跨多项式映射、线性代数和图算法的精确计算与猜想测试。
 - [quantstats](https://github.com/ranaroussi/quantstats) | `Python` | - 用 Python 编写的量化投资组合分析
 
 ### 指标 Indicators


### PR DESCRIPTION
在 `Readme.md` 和 `Readme_cn.md` 的分析工具清单中加入 Jacobian。两个 README 各新增一行，其他内容未修改。

Jacobian 是面向 Agent 的可组合数学工具，提供跨多项式映射、线性代数和图算法的精确计算与猜想测试，并同时提供 Python 库、CLI 和 MCP 接口。

它适合放在量化研究工具中，因为这些能力可以作为因子分析、组合优化和其他研究实验的数学计算基础；条目本身不把 Jacobian 描述成交易框架或行情数据源。

验证：

- `git diff --check`
- 仅修改两个 README，各新增一行。