### PR TITLE
Add marketlens to Prediction Markets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -468,6 +468,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [TurbineFi](https://turbinefi.com) | `Web` | - Build, backtest, and deploy automated trading strategies for prediction markets including Kalshi and Polymarket.
 - [TBD Predict](https://github.com/ego-protocol/tbd-vote-cli) | `TypeScript` | - Solana-based prediction market for human opinions with an agent CLI (`@tbd-vote/cli`) and AGENTS.md spec for AI agents to authenticate, list opinion campaigns, and place bets via JSON-friendly commands. [Website](https://www.tbd.vote)
 - [PolyMind](https://polyminds.netlify.app/) | - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Monitors 200+ markets every 15 seconds across 12 signal types: whale bets, volume spikes, price reversals, coordinated wallets, and more. Free tier available.
+- [marketlens](https://marketlens.trade) | `Python`, `REST API` | - Tick-level Polymarket L2 order book history covering the whole catalog (crypto, sports, weather, economics) from March 2026, served as REST or parquet exports, with a backtesting engine that models queue position, latency, slippage and settlement delay. Free tier, then from $39/mo. [GitHub](https://github.com/marketlenstrade/marketlens-python)
 
 ## Broker APIs
 


### PR DESCRIPTION
Adds marketlens under `Data Source` > `Prediction Markets`.

Polymarket order book history as a REST API and parquet exports, with a Python SDK (MIT) and a backtesting engine. What it adds over the entries already in the section: full-catalog book depth rather than crypto only, so sports, weather and economics markets are covered too, and execution modelling (queue position, latency, slippage, settlement delay) rather than signals or alerts.

- Data from 2026-03-01, tick-level L2 with snapshot plus delta chains.
- SDK: https://github.com/marketlenstrade/marketlens-python, v1.7.1 (2026-08-12), CI on Python 3.10-3.13.
- Docs: https://marketlens.trade/docs
- Free tier, paid from $39/mo.

Disclosure: I am the author.
