### PR TITLE
Add TickerAll to Broker APIs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -484,6 +484,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [pmxt](https://github.com/pmxt-dev/pmxt) | `Python`, `JavaScript` | - A JavaScript / Python prediction markets trading API with support for major exchanges. (The ccxt for prediction markets)
 - [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent skill for trading on Polymarket prediction markets. Non-custodial, whale signal detection, public leaderboard. Works as OpenClaw skill or Telegram Mini App.
 - [NanoStack](https://api.nano-labs.io) | `Rust`, `REST API` | - Permissionless cross-chain execution fabric. 86 chains, 8-15 bps fee, no API key required. Direct pool routing, conservation-enforced settlement, sub-millisecond dispatch.
+- [TickerAll](https://tickerall.com) | `REST`, `WebSocket` | - Hosted MetaTrader 5 & MT4 broker API. Place trades, stream live ticks, and pull historical candles from your code with no MetaTrader terminal — Python & TypeScript SDKs. Permanent free tier on demo accounts.
 - More is coming... (PR welcome)
 
 ## Quant Shops Code and Blog


### PR DESCRIPTION
Adds **TickerAll** to the **Broker APIs** section.

TickerAll is a hosted MetaTrader 5 & MT4 broker API (REST + WebSocket): place trades, stream live ticks, and pull historical candles from your code, with no local MetaTrader terminal — so a bot can run on Linux/macOS/containers. Python & TypeScript SDKs, and a permanent free tier on demo accounts.

Disclosure: I build TickerAll. Happy to tweak the wording or placement if you'd prefer.