### PR TITLE
Add Convex Lake to Data Source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -408,6 +408,7 @@ Note: the one marked as `Live Trading` has reasonable live trading support for a
 - [FilingFirehose](https://github.com/jaablon/filingfirehose-python) - SEC EDGAR JSON API with body-text-classified 8-Ks (catches buried items: 7.3% of Item 8.01 filings flagged), 13D/G with 21+ activist filers tagged, S-3/424B5 ATM detection. Free 72h tier, paid full archive from $29/mo. REST + MCP + Python SDK + GitHub Action.
 - [AltData Atlas](https://altdataatlas.com) - Open directory of alternative data providers for systematic and fundamental investors.
 - [polymarket-canary-tape](https://huggingface.co/datasets/oraclemangle/polymarket-canary-tape) - Free CC-BY-4.0 prediction-market microstructure tape: 271M CEX trades + 61M Polymarket order-book WebSocket events (Apr-Jul 2026), including a dual-vantage overlap window for latency studies. Companion open-source bot lab: [polymarket-bot-lab](https://github.com/oraclemangle/polymarket-bot-lab).
+- [Convex Lake](https://convexlake.com) - Unified REST API for prediction market and crypto derivatives data: batch and real-time trades, order books, and volatility surface across Kalshi, Polymarket, Predict.fun, Limitless, Deribit, and Binance options. Free academic-research tier on request.
 
 ### Stocks and General
 


### PR DESCRIPTION
Adds Convex Lake (https://convexlake.com) to the Data Source section. Unified REST API for prediction market and crypto derivatives data — Kalshi, Polymarket, Predict.fun, Limitless, Deribit, and Binance options, batch and real-time, one schema. Free academic-research tier on request.

Added next to polymarket-canary-tape, the other prediction-market microstructure entry in this section.